### PR TITLE
Don't error when no type is available

### DIFF
--- a/merlin-eldoc.el
+++ b/merlin-eldoc.el
@@ -367,7 +367,7 @@ non-nil."
     (while (not (equal previous-type type))
       (setq previous-type type)
       (setq type (merlin-eldoc--raw-type t)))
-    (merlin-eldoc--format-type type)))
+    (when type (merlin-eldoc--format-type type))))
 
 (defun merlin-eldoc--raw-doc ()
   "Return a string containing raw documentation of the thing at point."


### PR DESCRIPTION
merlin-eldoc--raw-type can return nil, but merlin-eldoc--format-type
only supports strings. This was fixed for merlin-eldoc--type in
3af7032, but the same issue existed in merlin-eldoc--verbose-type.