### PR TITLE
Address a couple of deprecation warnings

### DIFF
--- a/merlin-eldoc.el
+++ b/merlin-eldoc.el
@@ -225,7 +225,7 @@ before to call this function."
 
 (defun merlin-eldoc--fontify (s)
   "Fontify the string S."
-  (merlin/display-in-type-buffer s)
+  (merlin-display-in-type-buffer s)
   (with-current-buffer merlin-type-buffer-name
     (font-lock-fontify-region (point-min) (point-max))
     (buffer-string)))
@@ -502,8 +502,8 @@ Occurrences and position are meant to be used by
 
 (defun merlin-eldoc--occurrences ()
   "Produce list of BOUNDS (of the form (START . END)) of occurrences of the symbol at point."
-  (merlin/call "occurrences"
-               "-identifier-at" (merlin/unmake-point (point))))
+  (merlin-call "occurrences"
+               "-identifier-at" (merlin-unmake-point (point))))
 
 (defun merlin-eldoc--highlight-occurrence (bounds face)
   "Create an overlay on BOUNDS (of the form (START . END)) and give FACE."
@@ -565,8 +565,8 @@ Occurrences and position are meant to be used by
   "Return a string with expected types for function application."
   (interactive)
   (when merlin-eldoc-function-arguments
-    (let* ((data (merlin/call "complete-prefix"
-                              "-position" (merlin/unmake-point (point))
+    (let* ((data (merlin-call "complete-prefix"
+                              "-position" (merlin-unmake-point (point))
                               "-prefix" ""
                               "-doc" "n"))
            (context (cdr (assoc 'context data)))


### PR DESCRIPTION
Seems the Merlin package used to do namespacing with `merlin/`, but they've switched to the more traditional `merlin-`. 